### PR TITLE
Use any version of Django in setup.py to avoid conflicts with packages relying on legacy Django APIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     ],
     keywords='django data analytics',
     install_requires=[
-        'django>3', # I mean obviously you'll have django installed if you want to use this.
+        'django',  # I mean obviously you'll have django installed if you want to use this.
         'django-model-utils',
     ],
     develop_requires=[


### PR DESCRIPTION
For more information: https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis